### PR TITLE
fix(ci): supply-chain-security の secrets-in-if 修正 + Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: "/apps/budget-app"
     schedule:
       interval: "weekly"
+    # cooldown: 公開から指定日数が経つまで更新PRを作らない（公開直後の悪質バージョン回避）。
+    #   pnpm の minimumReleaseAge=7日 と整合。version更新のみ対象でセキュリティ更新は遅延しない。
+    cooldown:
+      default-days: 7
     # 同時に開くPR数を抑制（レビュー可能な範囲に）
     open-pull-requests-limit: 5
     # グループ更新: パッチ/マイナーをまとめて1つのPRに
@@ -40,6 +44,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # アクションの新バージョンも7日 cooldown（タグ付け直後の改ざん回避）
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       # アクション更新を1つのPRにまとめる

--- a/.github/workflows/supply-chain-security.yml
+++ b/.github/workflows/supply-chain-security.yml
@@ -34,6 +34,10 @@ env:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    env:
+      # secrets は if: で直接参照できない（ワークフロー全体が無効化される）。
+      # ジョブレベルの env に写し、ステップの if: では env.SOCKET_TOKEN を判定する。
+      SOCKET_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
     outputs:
       # 各スキャンの結果サマリ（Issue起票ステップが参照）
       critical_found: ${{ steps.summarize.outputs.critical_found }}
@@ -110,12 +114,12 @@ jobs:
       # ----------------------------------------------------------------
       - name: Socket security scan
         id: socket
-        if: ${{ secrets.SOCKET_SECURITY_API_KEY != '' }}
+        if: ${{ env.SOCKET_TOKEN != '' }}
         continue-on-error: true
         uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: cli
-          socket-token: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          socket-token: ${{ env.SOCKET_TOKEN }}
 
       - name: Record Socket result
         run: |


### PR DESCRIPTION
## 概要

マージ後に判明した2点を修正します。

## 🐛 修正1（重要）: supply-chain-security ワークフローが全実行で失敗していた

`supply-chain-security.yml` が **「workflow file issue」でジョブ0個・全 push で failure** になっていました。原因は Socket ステップの：

```yaml
if: ${{ secrets.SOCKET_SECURITY_API_KEY != '' }}   # ← secrets は if: で使えない
```

GitHub Actions は `secrets` コンテキストを `if:` で直接参照できず、**ワークフローファイル全体を無効化**します（ローカルの YAML 検証では妥当に見えるため見落とされていました）。

**修正**: secret をジョブレベルの `env` に写し、`if:` では `env` を判定する標準パターンへ：

```yaml
jobs:
  audit:
    env:
      SOCKET_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
    steps:
      - name: Socket security scan
        if: ${{ env.SOCKET_TOKEN != '' }}
        with:
          socket-token: ${{ env.SOCKET_TOKEN }}
```

これでワークフローがパースされ、実際にジョブが走るようになります。

## 🛡 修正2: Dependabot に cooldown を追加（7日）

Dependabot は pnpm の `minimumReleaseAge`(7日 cooldown) を尊重しないため、公開直後の版も即 PR 化していました。Dependabot 独自の `cooldown` を npm / github-actions 両方に追加し、**公開から7日経つまで更新PRを作らない**ように整合させます（version 更新のみ対象・**セキュリティ更新は遅延しない**）。

```yaml
cooldown:
  default-days: 7
```

## マージ後に起きること（想定）

- ワークフローが正常に走り出します。
- `pnpm audit` が `next@16.2.1`（`<16.2.5` advisory 該当）を検知し、`security` ラベルの Issue を自動起票する可能性が高いです（= issue 駆動フローが正しく動いている証拠）。Next.js 更新は別途対応。

## 検証

- 両 YAML の構文 OK / `if:` から `secrets` 参照を排除 / `env.SOCKET_TOKEN` 化を確認 / cooldown 追加を確認。
- （actionlint は当環境に未インストールのため未実行。修正はこの種エラーの定番パターン。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
