### PR TITLE
fix(ci): Dependabot PR の read-only トークンで supply-chain-security が失敗する問題を修正

### DIFF
--- a/.github/workflows/supply-chain-security.yml
+++ b/.github/workflows/supply-chain-security.yml
@@ -251,7 +251,10 @@ jobs:
       # PRコメント: 新規依存が増えていたら supply-chain-auditor レビューを要求
       # ----------------------------------------------------------------
       - name: Request supply-chain-auditor review on new deps
-        if: ${{ github.event_name == 'pull_request' && steps.lockfile_diff.outputs.new_deps == 'true' }}
+        # Dependabot PR は GITHUB_TOKEN が読み取り専用のため、コメント投稿(write)が 403 で失敗する。
+        # → Dependabot 以外の PR のみ実行し、万一の write 失敗でもジョブを落とさない（continue-on-error）。
+        if: ${{ github.event_name == 'pull_request' && steps.lockfile_diff.outputs.new_deps == 'true' && github.actor != 'dependabot[bot]' }}
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ADDED_DEPS: ${{ steps.lockfile_diff.outputs.added_deps }}
@@ -291,7 +294,9 @@ jobs:
   # ==================================================================
   report:
     needs: audit
-    if: ${{ always() && needs.audit.outputs.critical_found == 'true' }}
+    # Issue は main の状態を追跡する目的なので push / schedule / 手動実行でのみ起票する。
+    # PR（特に Dependabot PR は読み取り専用トークン）では起票せず、検出は PR のチェック結果に委ねる。
+    if: ${{ always() && needs.audit.outputs.critical_found == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 問題

Dependabot PR（#19/#20 など）で `supply-chain-security` ワークフローの **audit ジョブが失敗**していました。

原因は **Dependabot PR では `GITHUB_TOKEN` が読み取り専用**になる GitHub の仕様です。そのため：
- 「Request supply-chain-auditor review on new deps」ステップが **PRコメント投稿(write)で 403** → audit ジョブごと失敗。

※ アプリ自体は無傷です（#19/#20 をローカルの node 22 + dependabotピン版で検証 → install / `tsc --noEmit` / vitest 255テスト すべて pass）。落ちていたのは「PRに書き込む」操作だけ。

## 修正

- **コメントステップ**: Dependabot 以外の PR のみ実行（`github.actor != 'dependabot[bot]'`）＋ `continue-on-error: true`（万一の write 失敗でもジョブを落とさない）。
- **Issue 起票(report)ジョブ**: Issue は main の状態を追跡する目的なので **PR では起票しない**（`github.event_name != 'pull_request'`）。push / schedule / 手動実行でのみ起票。

これで Dependabot PR では **スキャン（pnpm audit / OSV / Socket / 注入検査・すべて read-only で可）だけが走り、チェックが緑**になります。push/schedule 時の Issue 起票フロー（#22 で実証済み）はそのまま維持。

## 補足: #19/#20 のマージについて

- `supply-chain-security` は **必須チェックではない**ため、この赤い×は #19/#20 のマージを**ブロックしません**。
- ローカル検証で安全確認済みのため、**#19/#20 はこのままマージして問題ありません**。本PRをマージすれば、今後の Dependabot PR は最初から緑になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
