### PR TITLE
feat(worldcup-kickoff): tier根拠/凡例UI・PC装飾・ライブスコアAPI評価+雛形 (#27 #28 #30)

### DIFF
--- a/apps/worldcup-kickoff/docs/live-score-api-evaluation.md
+++ b/apps/worldcup-kickoff/docs/live-score-api-evaluation.md
@@ -1,0 +1,164 @@
+# ライブスコア API 連携 評価ドキュメント
+
+- **対象**: worldcup-kickoff（全 SSG の Next.js アプリ、source of truth は openfootball 静的データ）
+- **目的**: 試合中のライブスコアを反映するための外部 API の比較・選定（GitHub issue #30）
+- **作成**: cost-analyzer（CFO 配下）
+- **調査日**: 2026-06-06
+- **前提**: `WorldCupRepository` 抽象化（`src/lib/data/repository.ts`）により、現状の `static-repository` を後付けで差し替え／合成可能。**オッズ・賭博系データは評価対象外（不使用）。**
+
+> ⚠️ 料金・規約は変動する。本書の数値は調査日時点の公式／公開情報に基づく。導入前に各 URL を再確認すること。
+
+---
+
+## 1. 結論（要約）
+
+| 項目 | 結論 |
+|------|------|
+| **第一候補** | **API-Football（api-sports.io）の Pro プラン $19/月** |
+| **フォールバック** | **football-data.org の Livescores アドオン €12/月**（10〜20 RPM・遅延少）、または **無料枠での擬似ライブ**（順位・確定スコアのみ） |
+| **不採用** | worldcupapi.com（**€499/月** と高額。個人/小規模アプリには不適） |
+
+**理由の核心**: football-data.org の **無料(Free)プランはライブスコアが「遅延」配信で、リアルタイムのライブスコアは有料の Livescores（€12/月〜）が必須**。一方 API-Football は **無料枠(100 req/日)から全エンドポイントにアクセス可**で、$19/月の Pro プラン(7,500 req/日)なら **15 秒間隔のライブ更新**にポーリング設計で十分耐える。W杯本番の試合数・ポーリング頻度・価格のバランスで API-Football が最良。
+
+---
+
+## 2. 3 API 比較表
+
+| 項目 | **football-data.org** | **API-Football (api-sports.io)** | **worldcupapi.com** |
+|------|----------------------|----------------------------------|---------------------|
+| **無料枠** | あり（Free Forever） | あり（Free Forever） | 7日間トライアルのみ |
+| **無料枠の上限** | **10 req/分**（登録済）／非認証は 100 req/24h・一覧のみ | **100 req/日** | トライアル後は有料のみ |
+| **無料枠でライブスコア** | ❌ **遅延配信**（リアルタイム不可。要 Livescores 有料） | ⭕ 可（全エンドポイント開放。ただし 100/日で実運用は厳しい） | ⭕（トライアル中） |
+| **ライブ更新間隔** | Livescores 有料時のみ準リアルタイム | **15 秒間隔**（in-play: スコア/イベント/ラインナップ/スタッツ） | 準リアルタイム（sub-second 応答を謳う） |
+| **2026 W杯カバレッジ** | ⚠️ **無料枠の "Worldcup" は要確認**（カバレッジ表では FIFA World Cup が有料ティア 49€〜 表記。本番試合のライブは Livescores 有料が現実的） | ⭕ **W杯2026 対応明記**（48チーム/16会場、league/season で取得。試合・スコア・順位・得点者） | ⭕ **W杯2026 専用**（試合/イベント/コメンタリ/ラインナップ/順位/得点者/1930〜の歴史） |
+| **最安の実用有料プラン** | **Livescores €12/月**（20 RPM・12コンペ） | **Pro $19/月**（7,500 req/日） | **€499/月**（200,000 req/日、超過 €0.0009/req） |
+| **上位プラン** | Standard €49（60 RPM/30コンペ）, Advanced €99, Pro €199 | Ultra $39（75,000/日）, Mega $99（150,000/日） | 単一プランのみ（公開情報上） |
+| **商用利用** | ⭕ 有料プランで可 | ⭕ 可（プランに依存） | ⭕（有料） |
+| **表示義務(attribution)** | ⭕ **必須**: 「Football data provided by the Football-Data.org API」をフッター等に表示 | 要確認（規約参照。一般に表示義務の言及は弱い） | 未確認 |
+| **キャッシュ可否** | キャッシュは推奨される運用（レート制御手段として許容） | 明示規約は要確認（ポーリング前提のため実質キャッシュ前提運用） | 未確認 |
+| **資格情報の扱い** | OSS リポジトリへの認証情報コミット禁止（規約明記） | 一般的なキー秘匿（サーバー側保持） | 未確認 |
+| **必要キー** | API トークン（X-Auth-Token ヘッダ） | API キー（x-apisports-key ヘッダ or RapidAPI 経由） | API キー |
+
+> 注: football-data.org のカバレッジ表で「Worldcup」が無料セクションに、別途「FIFA World Cup」が有料ティア(49€〜)に併記されている矛盾があり、**無料枠でカバーされるのが本大会のライブか／予選・過去大会のみか**は導入前に公式サポートへ要確認（後述リスク参照）。いずれにせよ**無料枠はライブスコアが遅延**のため、リアルタイム用途では有料前提で考える。
+
+---
+
+## 3. 評価軸ごとの詳細
+
+### 3.1 無料枠の有無と上限
+
+- **football-data.org**: 登録済 Free で **10 req/分**。非認証だと 24h で 100 req かつ一覧系のみ。無料枠でも 12 コンペ（World Cup を含むと記載）にアクセスできるが、**スコアは遅延**。
+- **API-Football**: **100 req/日**。全エンドポイントにアクセスできるのが強みだが、1日 100 では W杯当日の複数試合ポーリングには到底足りない（プロトタイプ・検証用）。
+- **worldcupapi.com**: 恒常無料枠なし（**7日トライアルのみ**）。
+
+### 3.2 レート制限とライブ更新の現実性（ポーリング耐性）
+
+- **API-Football Pro（$19/月・7,500 req/日）**: 15 秒間隔のデータ更新を謳う。**サーバー側で集約ポーリング**すれば、同時進行試合が多い日でも 7,500/日に収めやすい（後述設計案参照）。これが最有力の理由。
+- **football-data.org Livescores（€12/月・20 RPM）**: 20 req/分 = 試合当日のポーリングには十分。ただし無料(10 RPM)＋遅延では同時試合のリアルタイム性が不足。
+- **worldcupapi.com（200,000 req/日）**: 上限は潤沢だが価格(€499/月)が見合わない。**超過 €0.0009/req の従量課金**は上限なしで青天井になり得る → コスト急増リスクにフラグ。
+
+### 3.3 2026 W杯カバレッジ
+
+- **API-Football**: W杯2026（48チーム/16会場）を明示対応。league + season 指定で fixtures（試合・スコア）、events、lineups、standings、topscorers を取得可。SSG アプリの「ライブスコア＋順位反映」要件に直接合致。
+- **football-data.org**: World Cup の取り扱いはあるが、**本大会ライブは Livescores 有料が現実的**。無料枠カバレッジの正確な範囲は要確認。
+- **worldcupapi.com**: W杯専用に最適化。データ品質は高そうだが価格が壁。
+
+### 3.4 商用利用 / 表示義務 / キャッシュ
+
+- **football-data.org**: 商用は有料で可。**attribution 必須**（「Football data provided by the Football-Data.org API」をフッター等の視認できる場所に表示）。OSS への認証情報コミット禁止が規約明記。キャッシュはレート制御手段として許容される運用。
+- **API-Football**: 商用可（プラン依存）。表示義務・キャッシュ規約は導入前に最新 ToS を要確認。
+- **worldcupapi.com**: ToS の詳細（表示義務・キャッシュ可否）は**未確認**。Stripe 決済・「隠れ料金なし」を謳う点のみ確認。
+
+### 3.5 SSG + 一部 ISR/オンデマンド再検証への適合性
+
+- 本アプリは全 SSG が基本。ライブスコアは**ビルド時に焼き込めない動的データ**なので、ライブ部分のみ **ISR（短い revalidate）／オンデマンド再検証／Route Handler 経由のクライアント取得**に切り出すのが定石。
+- どの API でも「**サーバー側（Route Handler）でポーリングし、結果をキャッシュ → クライアントへ配信**」が基本形。これにより無料枠/レート制限内に収めつつ、attribution・キー秘匿・キャッシュ規約を満たせる。`WorldCupRepository` に `getLiveScores()` 等を追加し、`static-repository` と `live-repository` を合成する形が拡張しやすい。
+
+---
+
+## 4. 推奨と根拠
+
+### 第一候補: API-Football Pro（$19/月）
+
+1. **無料枠で全エンドポイントを検証可能** → 開発・PoC を無料で進め、本番直前に Pro($19/月)へ昇格できる。
+2. **15 秒のライブ更新 × 7,500 req/日** が、サーバー集約ポーリング設計と相性が良い（無料枠では 100/日で不足のため、本番は Pro 想定）。
+3. **W杯2026 を明示サポート**（試合・スコア・イベント・順位・得点者）。要件をワンストップで満たす。
+4. 月額が低く、**年額でも $228/年**と小規模アプリで負担可能。
+
+### フォールバック A: football-data.org Livescores（€12/月）
+
+- **attribution 表示を許容できるなら最安級**（年額 €144）。Premier League など他リーグへ将来拡張する場合の汎用性も高い。
+- ただし**無料枠はライブが遅延**のため「無料でリアルタイム」は不可。無料枠は順位・確定スコアの**準静的反映**に留める使い方なら有用。
+
+### フォールバック B: 無料枠での擬似ライブ（コストゼロ運用）
+
+- football-data.org Free（10 RPM）や API-Football Free（100/日）で、**ライブの秒単位更新は諦め、数分間隔で確定スコア・順位のみ更新**する割り切り。SSG + ISR(例: 60〜120 秒) で「ほぼライブ」を演出。コスト最優先ならここから始め、反響を見て有料へ昇格。
+
+### 不採用: worldcupapi.com
+
+- データは充実だが **€499/月（年額 €5,988）** は本アプリの規模に対し過大。**超過従量課金（€0.0009/req）が上限なし**でコスト急増リスクもあり、見送り。
+
+---
+
+## 5. リスク（規約／表示義務／コスト）
+
+| リスク | 内容 | 対応 |
+|--------|------|------|
+| **football-data.org の attribution 義務** | フッター等に指定文言の表示が必須。未表示は規約違反 | 採用時は UI に「Football data provided by the Football-Data.org API」を常設 |
+| **無料枠カバレッジの不確実性** | football-data.org の無料 "Worldcup" が本大会ライブか予選/過去のみか不明瞭。カバレッジ表では FIFA World Cup が有料 49€〜 表記 | 導入前に公式サポート／カバレッジ詳細で要確認（未確認） |
+| **無料枠ではリアルタイム不可** | football-data.org Free はスコア遅延。API-Football Free は 100 req/日で当日運用に不足 | 本番リアルタイムは有料前提で予算化 |
+| **API-Football の日次上限リセット** | 7,500 req/日を試合日に使い切ると **UTC 0時まで失敗**し続ける | サーバー集約ポーリング＋キャッシュで消費を抑制、当日見込みリクエストを試算 |
+| **worldcupapi の従量課金** | 200,000 req/日 超過で €0.0009/req（上限なし）→ 想定外の請求 | 不採用で回避 |
+| **キャッシュ・ToS の未確認項目** | API-Football / worldcupapi のキャッシュ・表示規約の詳細は未確認 | 採用候補の最新 ToS を導入前に精読（下記 URL） |
+| **キー漏洩** | クライアント直叩きはキー露出。football-data.org は OSS への認証情報コミットを規約で禁止 | **必ずサーバー側（Route Handler / Server Component）でキーを保持**し、クライアントへはスコアのみ返す |
+
+---
+
+## 6. ポーリング設計案（推奨: API-Football Pro 前提）
+
+### 方針
+- **クライアントから直接 API を叩かない。** Next.js の Route Handler（`app/api/live/route.ts` 等）または Server Component 内でサーバー集約ポーリングし、**キャッシュした結果をクライアントへ配信**。キー秘匿・レート節約・規約遵守を同時に満たす。
+- `WorldCupRepository` に `getLiveScores()` / 動的 `getGroupStandings()` を追加し、`live-repository`（API）と既存 `static-repository`（openfootball）を**合成**。試合が無い時間帯は静的データにフォールバック。
+
+### 更新間隔とキャッシュ
+- **試合中（in-play）**: サーバー側ポーリング **30〜60 秒間隔**（API 自体は 15 秒更新だが、表示用途は 30〜60 秒で十分。レート節約）。
+- **キックオフ前後/前後半・終了直後**: 一時的に短縮（例 20〜30 秒）可。
+- **試合が無い時間帯**: ポーリング停止 → 静的データ＋ISR で配信。
+- **クライアント**: SWR/ポーリング or ISR(`revalidate: 30`)。サーバーキャッシュ済みエンドポイントを叩くため、外部 API 消費は増えない。
+
+### 無料枠／レート制限に収める工夫
+- **集約**: 1 回のサーバーポーリングで「当日の全試合 fixtures」をまとめて取得し、1 リクエストで複数試合を更新（試合ごとに叩かない）。
+- **アクティブ時間帯のみ稼働**: 試合スケジュール（既存の openfootball 静的データ）から **キックオフ±数時間のウィンドウだけ**ポーリングを有効化。
+- **指数バックオフ**: 429/レート超過時はバックオフし、当日上限の枯渇を防止。
+- **概算消費（API-Football Pro / 7,500 req/日）**: 試合日に同時刻帯の試合を 1 リクエストで集約取得し 30 秒間隔 → 1 試合枠あたり ~120 req/時。W杯の 1 日あたり試合枠を踏まえても **数百〜千 req/日に収まり、7,500/日の上限に十分な余裕**。グループステージの多試合日でも集約取得なら破綻しにくい。
+
+### フォールバック構成
+1. ライブ API がエラー/上限 → 直近のサーバーキャッシュを返す。
+2. キャッシュも無効 → openfootball 静的データ（確定済みスコア/予定）を返す。
+3. UI に「ライブ更新中／最終更新時刻」を明示し、遅延・停止時もユーザー体験を維持。
+
+---
+
+## 7. 次アクション（導入前チェックリスト）
+
+- [ ] **football-data.org**: 無料 "Worldcup" が **本大会ライブを含むか** を公式サポート／カバレッジ詳細で確認（未確認）。
+- [ ] **API-Football**: 最新 ToS でキャッシュ可否・表示義務を確認。W杯2026 の league/season ID をドキュメントで特定。
+- [ ] 採用 API の**試合日リクエスト消費を実測/試算**し、プラン上限と突き合わせ。
+- [ ] attribution 表示（football-data.org 採用時）を UI 要件に追加。
+- [ ] キーは**サーバー側のみ**で保持する実装方針を CTO 配下に共有（`live-repository` 設計）。
+
+---
+
+## 参照（調査日: 2026-06-06）
+
+- football-data.org Pricing — https://www.football-data.org/pricing
+- football-data.org Coverage — https://www.football-data.org/coverage
+- football-data.org API policies — https://docs.football-data.org/general/v4/policies.html
+- football-data.org FAQ/Help（attribution・規約） — https://www.football-data.org/documentation/faq
+- football-data.org Free Tier 分析（2026, TheStatsAPI） — https://www.thestatsapi.com/blog/football-data-org-free-tier-limits-2026
+- API-Football Pricing — https://www.api-football.com/pricing
+- API-Sports Football（製品情報） — https://api-sports.io/sports/football
+- API-Football ratelimit 解説 — https://www.api-football.com/news/post/how-ratelimit-works
+- API-Football「FIFA World Cup 2026 Guide」（HTTP 403 で本文未取得、検索結果で W杯2026 対応を確認） — https://www.api-football.com/news/post/fifa-world-cup-2026-guide-to-using-data-with-api-sports
+- worldcupapi.com Pricing — https://worldcupapi.com/pricing
+- worldcupapi.com（製品情報） — https://worldcupapi.com/

--- a/apps/worldcup-kickoff/src/app/countries/page.tsx
+++ b/apps/worldcup-kickoff/src/app/countries/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
+import { Info } from 'lucide-react'
 import { ListDetailTemplate } from '@/components/templates/ListDetailTemplate'
 import { CountryListItem } from '@/components/molecules/CountryListItem'
 import { FavoriteToggle } from '@/components/molecules/FavoriteToggle'
+import { TierLegendDialog } from '@/components/molecules/TierLegendDialog'
 import {
   GroupStandings,
   type GroupStandingsEntry,
@@ -110,6 +112,16 @@ export default async function CountriesPage() {
       title="国図鑑"
       description="出場48ヶ国をグループ別に。気になる国をタップして、推し国を見つけよう。"
     >
+      {/* バッジ（優勝候補・ダークホース等）の意味＝凡例への導線 */}
+      <div>
+        <TierLegendDialog
+          triggerClassName="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1.5 text-xs font-bold text-text-muted transition-colors hover:bg-pitch-50 hover:text-text"
+          triggerAriaLabel="ランクの見方を開く"
+        >
+          <Info className="h-4 w-4" aria-hidden />
+          ランク（優勝候補・ダークホースなど）の見方
+        </TierLegendDialog>
+      </div>
       <CountriesView list={listNode} standings={standingsNode} />
     </ListDetailTemplate>
   )

--- a/apps/worldcup-kickoff/src/app/globals.css
+++ b/apps/worldcup-kickoff/src/app/globals.css
@@ -55,6 +55,23 @@
 
   /* ── 角丸（カード = 2xl 基調） ── */
   --radius-card: 1rem;
+
+  /*
+   * PC ガター装飾（DeskDecor）の紙吹雪用。非常にゆっくり上下に浮遊する。
+   * Tailwind v4 の utility `animate-float` として参照する。
+   * prefers-reduced-motion 時は下の @media で無効化される。
+   */
+  --animate-float: float 9s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
 }
 
 /*

--- a/apps/worldcup-kickoff/src/app/layout.tsx
+++ b/apps/worldcup-kickoff/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Noto_Sans_JP } from 'next/font/google'
 import './globals.css'
 import { FavoriteTeamProvider } from '@/components/providers/FavoriteTeamProvider'
+import { DeskDecor } from '@/components/organisms/DeskDecor'
 import { SiteHeader } from '@/components/organisms/SiteHeader'
 import { BottomNav } from '@/components/organisms/BottomNav'
 
@@ -76,6 +77,12 @@ export default function RootLayout({
       <body className="min-h-dvh bg-bg text-text antialiased">
         <FavoriteTeamProvider>
           {/*
+            PC（lg+）の広い左右余白を上品に飾る純装飾レイヤ（最背面 z-0・最前面の
+            固定要素より後ろ）。lg 未満では描画されず、モバイルの見た目は不変。
+            body の bg-bg は維持し、中央 480px 列には掛けない。
+          */}
+          <DeskDecor />
+          {/*
             アプリ全体は中央寄せ・最大幅 ~480px のモバイルファースト枠。
             上下の固定要素（SiteHeader: fixed top-0 / h-14、BottomNav: fixed bottom-0 / h-16）に
             重ならないよう、<main> に pt-14 / pb-16 を確保している。
@@ -91,7 +98,7 @@ export default function RootLayout({
             overflow-y を visible のまま残せるため、横あふれだけを切り取りつつ
             sticky を維持できる。ブラケット等の横スクロールは内側コンテナで完結させる。
           */}
-          <main className="mx-auto w-full max-w-[480px] overflow-x-clip px-4 pt-14 pb-16">
+          <main className="relative z-10 mx-auto w-full max-w-[480px] overflow-x-clip px-4 pt-14 pb-16">
             {children}
           </main>
           <BottomNav />

--- a/apps/worldcup-kickoff/src/components/molecules/CountryListItem/CountryListItem.tsx
+++ b/apps/worldcup-kickoff/src/components/molecules/CountryListItem/CountryListItem.tsx
@@ -2,15 +2,9 @@ import Link from 'next/link'
 import { ChevronRight } from 'lucide-react'
 import { CountryFlag } from '@/components/atoms/CountryFlag'
 import { Badge } from '@/components/atoms/Badge'
+import { TIER_META } from '@/lib/constants/tiers'
 import { cn } from '@/lib/utils/cn'
 import type { TeamTier } from '@/lib/domain'
-
-/** tier → 日本語ラベル + バッジ色 */
-const TIER_META: Record<TeamTier, { label: string; variant: 'gold' | 'pitch' | 'neutral' }> = {
-  favorite: { label: '優勝候補', variant: 'gold' },
-  darkhorse: { label: 'ダークホース', variant: 'pitch' },
-  underdog: { label: 'チャレンジャー', variant: 'neutral' },
-}
 
 export interface CountryListItemProps {
   /** 国旗絵文字 */

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegend/TierLegend.test.tsx
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegend/TierLegend.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TierLegend } from './TierLegend'
+import {
+  TIER_DISCLAIMER_JA,
+  TIER_META,
+  TIER_ORDER,
+} from '@/lib/constants/tiers'
+
+describe('TierLegend', () => {
+  it('3つの tier のラベルが表示される', () => {
+    render(<TierLegend />)
+    expect(screen.getByText('優勝候補')).toBeInTheDocument()
+    expect(screen.getByText('ダークホース')).toBeInTheDocument()
+    expect(screen.getByText('チャレンジャー')).toBeInTheDocument()
+  })
+
+  it('各 tier の意味（summaryJa）が表示される', () => {
+    render(<TierLegend />)
+    for (const tier of TIER_ORDER) {
+      expect(screen.getByText(TIER_META[tier].summaryJa)).toBeInTheDocument()
+    }
+  })
+
+  it('各 tier の基準（criteriaJa）が表示される', () => {
+    render(<TierLegend />)
+    for (const tier of TIER_ORDER) {
+      expect(screen.getByText(TIER_META[tier].criteriaJa)).toBeInTheDocument()
+    }
+  })
+
+  it('主観・目安である旨の注記が表示される', () => {
+    render(<TierLegend />)
+    expect(screen.getByText(TIER_DISCLAIMER_JA)).toBeInTheDocument()
+  })
+
+  it('TIER_ORDER の順（優勝候補→ダークホース→チャレンジャー）で並ぶ', () => {
+    const { container } = render(<TierLegend />)
+    const labels = TIER_ORDER.map((tier) => TIER_META[tier].label)
+    // 各ラベルの DOM 出現位置を取得し、TIER_ORDER 通りの並びかを確認する
+    const text = container.textContent ?? ''
+    const positions = labels.map((label) => text.indexOf(label))
+    expect(positions.every((p) => p >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+  })
+})

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegend/TierLegend.tsx
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegend/TierLegend.tsx
@@ -1,0 +1,48 @@
+import { Badge } from '@/components/atoms/Badge'
+import { Card } from '@/components/atoms/Card'
+import {
+  TIER_DISCLAIMER_JA,
+  TIER_META,
+  TIER_ORDER,
+} from '@/lib/constants/tiers'
+import { cn } from '@/lib/utils/cn'
+
+export interface TierLegendProps {
+  className?: string
+}
+
+/**
+ * ランク（tier）の凡例。優勝候補 → ダークホース → チャレンジャーの順に、
+ * バッジ・意味（summaryJa）・基準（criteriaJa）を1行ずつ並べ、最後に注記を添える。
+ *
+ * 文言・配色は `@/lib/constants/tiers` の単一定義（TIER_META 等）を参照し、
+ * バッジに使う国図鑑側の表記と必ず一致させる。
+ * 表示専用のため Server Component（'use client' 不要）。見出しは呼び出し側が付ける。
+ */
+export function TierLegend({ className }: TierLegendProps) {
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <ul className="flex flex-col gap-2">
+        {TIER_ORDER.map((tier) => {
+          const meta = TIER_META[tier]
+          return (
+            <li key={tier}>
+              <Card padding="md" className="flex flex-col gap-1.5">
+                <Badge variant={meta.variant} className="self-start">
+                  {meta.label}
+                </Badge>
+                <p className="text-sm font-bold text-text">{meta.summaryJa}</p>
+                <p className="text-xs leading-relaxed text-text-muted">
+                  {meta.criteriaJa}
+                </p>
+              </Card>
+            </li>
+          )
+        })}
+      </ul>
+      <p className="text-xs leading-relaxed text-text-muted">
+        {TIER_DISCLAIMER_JA}
+      </p>
+    </div>
+  )
+}

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegend/index.ts
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegend/index.ts
@@ -1,0 +1,2 @@
+export { TierLegend } from './TierLegend'
+export type { TierLegendProps } from './TierLegend'

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/TierLegendDialog.test.tsx
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/TierLegendDialog.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TierLegendDialog } from './TierLegendDialog'
+import { TIER_META } from '@/lib/constants/tiers'
+
+const TRIGGER_LABEL = 'ランクの見方を開く'
+
+function renderDialog(title?: string) {
+  return render(
+    <TierLegendDialog triggerAriaLabel={TRIGGER_LABEL} title={title}>
+      <span>ダークホース</span>
+    </TierLegendDialog>,
+  )
+}
+
+describe('TierLegendDialog', () => {
+  it('トリガーボタンが表示される', () => {
+    renderDialog()
+    expect(
+      screen.getByRole('button', { name: TRIGGER_LABEL }),
+    ).toBeInTheDocument()
+  })
+
+  it('初期状態ではダイアログが閉じている', () => {
+    renderDialog()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: TRIGGER_LABEL }),
+    ).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('トリガーは aria-haspopup="dialog" を持つ', () => {
+    renderDialog()
+    expect(
+      screen.getByRole('button', { name: TRIGGER_LABEL }),
+    ).toHaveAttribute('aria-haspopup', 'dialog')
+  })
+
+  it('クリックでダイアログが開き、見出しと凡例内容が表示される', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: TRIGGER_LABEL }))
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'ランク（tier）の見方' }),
+    ).toBeInTheDocument()
+    // 凡例（TierLegend）の中身が見えている
+    expect(
+      screen.getByText(TIER_META.favorite.criteriaJa),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: TRIGGER_LABEL }),
+    ).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('title を渡すと見出しが差し替わる', async () => {
+    const user = userEvent.setup()
+    renderDialog('ランクってなに？')
+    await user.click(screen.getByRole('button', { name: TRIGGER_LABEL }))
+    expect(
+      screen.getByRole('heading', { name: 'ランクってなに？' }),
+    ).toBeInTheDocument()
+  })
+
+  it('開くと閉じるボタンにフォーカスが移る', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: TRIGGER_LABEL }))
+    expect(screen.getByRole('button', { name: '閉じる' })).toHaveFocus()
+  })
+
+  it('Escape で閉じてトリガーへフォーカスが戻る', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const trigger = screen.getByRole('button', { name: TRIGGER_LABEL })
+    await user.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('閉じるボタンで閉じてトリガーへフォーカスが戻る', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const trigger = screen.getByRole('button', { name: TRIGGER_LABEL })
+    await user.click(trigger)
+    await user.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('バックドロップのクリックで閉じる', async () => {
+    const user = userEvent.setup()
+    const { container } = renderDialog()
+    const trigger = screen.getByRole('button', { name: TRIGGER_LABEL })
+    await user.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // role=dialog の外側（オーバーレイ最外殻）をクリックして閉じる
+    const dialog = screen.getByRole('dialog')
+    const overlay = dialog.parentElement as HTMLElement
+    expect(overlay).not.toBeNull()
+    expect(container.contains(overlay)).toBe(true)
+    await user.click(overlay)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+})

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/TierLegendDialog.tsx
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/TierLegendDialog.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { TierLegend } from '@/components/molecules/TierLegend'
+
+export interface TierLegendDialogProps {
+  /** トリガー（ボタン）の中身。バッジやアイコン+テキストなど */
+  children: React.ReactNode
+  /** トリガーボタンの追加クラス */
+  triggerClassName?: string
+  /** トリガーの aria-label（中身がテキストでない/補足したいとき） */
+  triggerAriaLabel?: string
+  /** ダイアログ見出し */
+  title?: string
+}
+
+/**
+ * バッジ等のトリガーから開く「ランク（tier）の見方」モーダルダイアログ。
+ * Radix 等は使わず、ネイティブ button + 自前の軽量ダイアログで実装する。
+ * 中身は表示専用の TierLegend を流用する。
+ *
+ * A11y:
+ * - トリガーは `<button aria-haspopup="dialog" aria-expanded aria-controls>`。
+ * - パネルは `role="dialog" aria-modal="true" aria-labelledby`。
+ * - 開いたら閉じるボタンへフォーカス移動。Escape / バックドロップで閉じて
+ *   トリガーへフォーカスを戻す。開いている間は body スクロールを抑止。
+ * Client Component。
+ */
+export function TierLegendDialog({
+  children,
+  triggerClassName,
+  triggerAriaLabel,
+  title = 'ランク（tier）の見方',
+}: TierLegendDialogProps) {
+  const [open, setOpen] = useState(false)
+  const id = useId()
+  const dialogId = `tier-legend-dialog-${id}`
+  const titleId = `tier-legend-dialog-title-${id}`
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  const close = useCallback((returnFocus: boolean) => {
+    setOpen(false)
+    if (returnFocus) triggerRef.current?.focus()
+  }, [])
+
+  // 開いたら閉じるボタンへフォーカスを移動（モーダルの起点を明示）
+  useEffect(() => {
+    if (!open) return
+    closeButtonRef.current?.focus()
+  }, [open])
+
+  // Escape で閉じる + トリガーへフォーカスを戻す（TermPopover 同様 document リスナ）
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        close(true)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, close])
+
+  // 開いている間は背後のスクロールを抑止（effect 内のみ DOM に触れ SSR セーフに）
+  useEffect(() => {
+    if (!open) return
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+    return () => {
+      body.style.overflow = previousOverflow
+    }
+  }, [open])
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? dialogId : undefined}
+        aria-label={triggerAriaLabel}
+        onClick={() => setOpen(true)}
+        className={triggerClassName}
+      >
+        {children}
+      </button>
+
+      {open ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          // バックドロップのクリックで閉じる（トリガーへフォーカスを戻す）。
+          // パネル内クリックは下の onClick stopPropagation で抑止する。
+          onClick={() => close(true)}
+        >
+          {/* 半透明バックドロップ */}
+          <div aria-hidden className="absolute inset-0 bg-black/40" />
+          <div
+            id={dialogId}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            onClick={(e) => e.stopPropagation()}
+            className="relative z-10 flex max-h-[85vh] w-full max-w-[90vw] flex-col rounded-2xl bg-surface shadow-md sm:max-w-md"
+          >
+            <div className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
+              <h2 id={titleId} className="text-base font-bold text-text">
+                {title}
+              </h2>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                aria-label="閉じる"
+                onClick={() => close(true)}
+                className="-mr-1 -mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-text-muted transition-colors hover:bg-pitch-50 hover:text-text"
+              >
+                <X className="h-5 w-5" aria-hidden />
+              </button>
+            </div>
+            <div className="overflow-y-auto px-4 py-4">
+              <TierLegend />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/index.ts
+++ b/apps/worldcup-kickoff/src/components/molecules/TierLegendDialog/index.ts
@@ -1,0 +1,2 @@
+export { TierLegendDialog } from './TierLegendDialog'
+export type { TierLegendDialogProps } from './TierLegendDialog'

--- a/apps/worldcup-kickoff/src/components/organisms/CountryDetailPanel/CountryDetailPanel.test.tsx
+++ b/apps/worldcup-kickoff/src/components/organisms/CountryDetailPanel/CountryDetailPanel.test.tsx
@@ -18,6 +18,7 @@ const team: Team = {
   region: 'asia',
   style: 'balanced',
   tier: 'darkhorse',
+  tierReasonJa: '組織的なサッカーで上位を脅かす力があるからです。',
   blurbJa: 'アジアの強豪、サムライブルー。',
   watchPointJa: '全員で連動する組織的な守備が見どころ。',
   funFactsJa: ['7大会連続出場', '愛称はサムライブルー'],
@@ -142,5 +143,37 @@ describe('CountryDetailPanel', () => {
       />,
     )
     expect(screen.getByText('試合はまだありません')).toBeInTheDocument()
+  })
+
+  it('tier の理由（tierReasonJa）が表示される', () => {
+    renderPanel(
+      <CountryDetailPanel
+        team={team}
+        groupLabel="グループA"
+        players={players}
+        matches={matches}
+      />,
+    )
+    expect(
+      screen.getByText('組織的なサッカーで上位を脅かす力があるからです。'),
+    ).toBeInTheDocument()
+    // 「なぜ◯◯？」の見出し（tier ラベルを含む）
+    expect(screen.getByText(/なぜダークホース？/)).toBeInTheDocument()
+  })
+
+  it('tier バッジがランク凡例ダイアログのトリガーになっている', () => {
+    renderPanel(
+      <CountryDetailPanel
+        team={team}
+        groupLabel="グループA"
+        players={players}
+        matches={matches}
+      />,
+    )
+    const trigger = screen.getByRole('button', {
+      name: /ランクの見方を開く/,
+    })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
   })
 })

--- a/apps/worldcup-kickoff/src/components/organisms/CountryDetailPanel/CountryDetailPanel.tsx
+++ b/apps/worldcup-kickoff/src/components/organisms/CountryDetailPanel/CountryDetailPanel.tsx
@@ -6,13 +6,10 @@ import { Tag } from '@/components/atoms/Tag'
 import { EmptyState } from '@/components/atoms/EmptyState'
 import { FavoriteToggle } from '@/components/molecules/FavoriteToggle'
 import { MatchCard, type MatchCardTeam } from '@/components/molecules/MatchCard'
+import { TierLegendDialog } from '@/components/molecules/TierLegendDialog'
+import { TIER_META } from '@/lib/constants/tiers'
 import { cn } from '@/lib/utils/cn'
-import type {
-  Player,
-  PlayerPosition,
-  Team,
-  TeamTier,
-} from '@/lib/domain'
+import type { Player, PlayerPosition, Team } from '@/lib/domain'
 
 /** CountryDetailPanel が描画する1試合分の表示データ（page でシリアライズ可能に整形） */
 export interface CountryMatchView {
@@ -36,15 +33,6 @@ export interface CountryDetailPanelProps {
   /** その国の試合（page で整形済み・キックオフ昇順想定） */
   matches: CountryMatchView[]
   className?: string
-}
-
-const TIER_META: Record<
-  TeamTier,
-  { label: string; variant: 'gold' | 'pitch' | 'neutral' }
-> = {
-  favorite: { label: '優勝候補', variant: 'gold' },
-  darkhorse: { label: 'ダークホース', variant: 'pitch' },
-  underdog: { label: 'チャレンジャー', variant: 'neutral' },
 }
 
 const POSITION_ORDER: PlayerPosition[] = ['GK', 'DF', 'MF', 'FW']
@@ -106,8 +94,23 @@ export function CountryDetailPanel({
           <h1 className="text-3xl font-extrabold text-text">{team.nameJa}</h1>
           <div className="flex flex-wrap items-center justify-center gap-2">
             <Badge variant="neutral">{groupLabel}</Badge>
-            <Badge variant={tierMeta.variant}>{tierMeta.label}</Badge>
+            {/* tier バッジをタップすると凡例モーダルが開く（cursor-help + リングで手掛かり） */}
+            <TierLegendDialog
+              triggerClassName="rounded-full transition-shadow hover:ring-2 hover:ring-pitch-200 focus-visible:ring-2 focus-visible:ring-pitch-200"
+              triggerAriaLabel={`${tierMeta.label}とは？ランクの見方を開く`}
+            >
+              <Badge variant={tierMeta.variant} className="cursor-help">
+                {tierMeta.label}
+              </Badge>
+            </TierLegendDialog>
           </div>
+          {/* なぜその tier なのかの一言理由 */}
+          <p className="max-w-prose text-center text-sm leading-relaxed">
+            <span className="font-bold text-pitch-700">
+              なぜ{tierMeta.label}？
+            </span>{' '}
+            <span className="text-text-muted">{team.tierReasonJa}</span>
+          </p>
         </div>
         <FavoriteToggle teamCode={team.code} nameJa={team.nameJa} showLabel />
       </header>

--- a/apps/worldcup-kickoff/src/components/organisms/DeskDecor/DeskDecor.test.tsx
+++ b/apps/worldcup-kickoff/src/components/organisms/DeskDecor/DeskDecor.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { DeskDecor } from './DeskDecor'
+
+describe('DeskDecor', () => {
+  it('ルートは aria-hidden の純装飾である', () => {
+    const { container } = render(<DeskDecor />)
+    const root = container.firstElementChild as HTMLElement
+    expect(root).not.toBeNull()
+    expect(root).toHaveAttribute('aria-hidden')
+  })
+
+  it('読み上げ・操作対象になる role を持たない（純装飾）', () => {
+    const { container } = render(<DeskDecor />)
+    // ボタン・リンク等のインタラクティブ要素を持たない
+    expect(container.querySelector('button')).toBeNull()
+    expect(container.querySelector('a')).toBeNull()
+    // SVG は presentation（装飾）扱い。それ以外の意味のある role は付与しない
+    const rolefulButNotPresentation = Array.from(
+      container.querySelectorAll('[role]'),
+    ).filter((el) => el.getAttribute('role') !== 'presentation')
+    expect(rolefulButNotPresentation).toHaveLength(0)
+  })
+
+  it('装飾用 SVG（presentation）が描画される', () => {
+    const { container } = render(<DeskDecor />)
+    const svgs = container.querySelectorAll('svg')
+    expect(svgs.length).toBeGreaterThan(0)
+    // SVG は presentation（読み上げ対象外の装飾）として描画される
+    expect(
+      container.querySelector('svg[role="presentation"]'),
+    ).not.toBeNull()
+  })
+
+  it('className を root にマージできる', () => {
+    const { container } = render(<DeskDecor className="custom-decor" />)
+    const root = container.firstElementChild as HTMLElement
+    expect(root).toHaveClass('custom-decor')
+  })
+})

--- a/apps/worldcup-kickoff/src/components/organisms/DeskDecor/DeskDecor.tsx
+++ b/apps/worldcup-kickoff/src/components/organisms/DeskDecor/DeskDecor.tsx
@@ -1,0 +1,153 @@
+import { cn } from '@/lib/utils/cn'
+
+export interface DeskDecorProps {
+  className?: string
+}
+
+/**
+ * PC（lg 以上）専用の左右ガター装飾。本文（中央 max-w-480px 列）の外側だけを
+ * ピッチグリーン基調 + ゴールド差し色 + W杯レッドで上品に飾る。
+ *
+ * 設計方針:
+ * - `hidden lg:block` で lg 未満では一切描画しない（モバイルの見た目を変えない）。
+ * - `fixed inset-0 overflow-hidden` で横スクロールを絶対に生まない。最背面 z-0。
+ * - `pointer-events-none aria-hidden` で操作・読み上げに干渉しない純装飾。
+ * - 中央列に被らないよう、左右ガター幅を `calc((100vw-30rem)/2)`（30rem=480px）で算出。
+ * - 写真は使わず、CSS グラデーション + 自作 SVG のみ。淡色・低 opacity で可読性を損なわない。
+ *
+ * 表示専用のため Server Component（'use client' 不要）。
+ */
+export function DeskDecor({ className }: DeskDecorProps) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none fixed inset-0 z-0 hidden overflow-hidden lg:block',
+        className,
+      )}
+    >
+      {/* 中央 480px 列に被らないガター幅。本文の隙間に派手に出ないよう淡く保つ。 */}
+      <Gutter side="left" />
+      <Gutter side="right" />
+    </div>
+  )
+}
+
+/** 左右どちらかのガター（中央480px列の外側）に装飾を敷く */
+function Gutter({ side }: { side: 'left' | 'right' }) {
+  return (
+    <div
+      className={cn(
+        'absolute inset-y-0 w-[max(0px,calc((100vw-30rem)/2))]',
+        side === 'left' ? 'left-0' : 'right-0',
+      )}
+    >
+      {/* ピッチの芝目（縦縞）。極薄の pitch でうっすら陰影をつける。 */}
+      <div
+        className="absolute inset-0 opacity-40"
+        style={{
+          backgroundImage:
+            'repeating-linear-gradient(90deg, var(--color-pitch-50) 0, var(--color-pitch-50) 14px, transparent 14px, transparent 28px)',
+        }}
+      />
+
+      {/* 紙吹雪（gold / pitch / kickoff の小さな丸）。motion-safe で非常にゆっくり浮遊。 */}
+      <Confetti side={side} />
+
+      {/* 大きく淡いシルエット（左=トロフィー / 右=サッカーボール）をガター下部に。 */}
+      <div
+        className={cn(
+          'absolute bottom-6 text-pitch-100 opacity-30',
+          side === 'left' ? 'left-6' : 'right-6',
+        )}
+      >
+        {side === 'left' ? <TrophySilhouette /> : <BallSilhouette />}
+      </div>
+    </div>
+  )
+}
+
+/** ガター内に疎に散らした紙吹雪。色・位置は左右で少しずらす。 */
+function Confetti({ side }: { side: 'left' | 'right' }) {
+  // ガター内の相対位置（%）。疎に・上品に。
+  const dots =
+    side === 'left'
+      ? [
+          { top: '12%', left: '24%', color: 'bg-gold-300', delay: '0s' },
+          { top: '28%', left: '62%', color: 'bg-pitch-300', delay: '1.5s' },
+          { top: '46%', left: '18%', color: 'bg-kickoff-300', delay: '0.8s' },
+          { top: '64%', left: '54%', color: 'bg-gold-200', delay: '2.2s' },
+          { top: '80%', left: '32%', color: 'bg-pitch-200', delay: '1.1s' },
+        ]
+      : [
+          { top: '16%', left: '58%', color: 'bg-pitch-300', delay: '0.5s' },
+          { top: '34%', left: '22%', color: 'bg-gold-300', delay: '1.9s' },
+          { top: '52%', left: '66%', color: 'bg-gold-200', delay: '1.2s' },
+          { top: '70%', left: '30%', color: 'bg-kickoff-300', delay: '0.3s' },
+          { top: '86%', left: '60%', color: 'bg-pitch-200', delay: '2.5s' },
+        ]
+
+  return (
+    <div className="absolute inset-0">
+      {dots.map((dot, i) => (
+        <span
+          key={i}
+          className={cn(
+            'absolute h-2 w-2 rounded-full opacity-50 motion-safe:animate-float',
+            dot.color,
+          )}
+          style={{
+            top: dot.top,
+            left: dot.left,
+            animationDelay: dot.delay,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** トロフィーのシルエット（currentColor で塗る・淡色） */
+function TrophySilhouette() {
+  return (
+    <svg
+      width="160"
+      height="200"
+      viewBox="0 0 160 200"
+      fill="currentColor"
+      role="presentation"
+    >
+      {/* カップ本体 */}
+      <path d="M48 24h64v40a32 32 0 0 1-64 0V24Z" />
+      {/* 左右の取っ手 */}
+      <path d="M48 32H30a14 14 0 0 0 0 28h6v-12h-6a2 2 0 0 1 0-4h12v-12Z" />
+      <path d="M112 32h18a14 14 0 0 1 0 28h-6v-12h6a2 2 0 0 0 0-4h-12v-12Z" />
+      {/* ステム + 台座 */}
+      <path d="M72 96h16v28H72z" />
+      <path d="M52 124h56v12H52z" />
+      <path d="M44 142h72v18H44z" />
+    </svg>
+  )
+}
+
+/** サッカーボールのシルエット（簡略な五角形パターン・淡色） */
+function BallSilhouette() {
+  return (
+    <svg
+      width="180"
+      height="180"
+      viewBox="0 0 180 180"
+      fill="currentColor"
+      role="presentation"
+    >
+      <circle cx="90" cy="90" r="78" />
+      <path
+        d="M90 52l24 17-9 28H75l-9-28 24-17Zm0 0V20m24 49l30-10m-21 56 19 25m-83-25-19 25M66 69l-30-10"
+        fill="none"
+        stroke="var(--color-surface)"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/apps/worldcup-kickoff/src/components/organisms/DeskDecor/index.ts
+++ b/apps/worldcup-kickoff/src/components/organisms/DeskDecor/index.ts
@@ -1,0 +1,2 @@
+export { DeskDecor } from './DeskDecor'
+export type { DeskDecorProps } from './DeskDecor'

--- a/apps/worldcup-kickoff/src/components/organisms/DiagnosisQuiz/DiagnosisQuiz.test.tsx
+++ b/apps/worldcup-kickoff/src/components/organisms/DiagnosisQuiz/DiagnosisQuiz.test.tsx
@@ -21,6 +21,7 @@ function makeTeam(code: string, overrides: Partial<Team> = {}): Team {
     region: 'europe',
     style: 'attacking',
     tier: 'favorite',
+    tierReasonJa: '実績と地力があり優勝を狙えるからです。',
     blurbJa: `${code} の紹介`,
     watchPointJa: '見どころ',
     funFactsJa: [],

--- a/apps/worldcup-kickoff/src/data/countries-content.json
+++ b/apps/worldcup-kickoff/src/data/countries-content.json
@@ -10,8 +10,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "ヨーロッパの伝統国で、堅い守りと技術で上を狙えるチームです。",
     "region": "europe",
-    "vibeJa": ["伝統国", "組織力", "粘り強さ"]
+    "vibeJa": [
+      "伝統国",
+      "組織力",
+      "粘り強さ"
+    ]
   },
   {
     "code": "KOR",
@@ -24,8 +29,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "アジアを代表する常連で、走力と気迫で上位を脅かせるチームです。",
     "region": "asia",
-    "vibeJa": ["運動量", "気迫", "アジアの雄"]
+    "vibeJa": [
+      "運動量",
+      "気迫",
+      "アジアの雄"
+    ]
   },
   {
     "code": "MEX",
@@ -38,8 +48,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "W杯ほぼ皆勤の常連で、地元開催の今回は特に勢いに乗れそうです。",
     "region": "north_america",
-    "vibeJa": ["テクニック", "陽気", "熱狂サポーター"]
+    "vibeJa": [
+      "テクニック",
+      "陽気",
+      "熱狂サポーター"
+    ]
   },
   {
     "code": "RSA",
@@ -52,8 +67,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "アフリカの南からやってきた、強豪に明るく挑む挑戦者です。",
     "region": "africa",
-    "vibeJa": ["スピード", "陽気", "旋風"]
+    "vibeJa": [
+      "スピード",
+      "陽気",
+      "旋風"
+    ]
   },
   {
     "code": "BIH",
@@ -66,8 +86,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "東欧の若い国で、大舞台で格上に挑むフレッシュなチームです。",
     "region": "europe",
-    "vibeJa": ["伏兵", "力強さ", "粘り強さ"]
+    "vibeJa": [
+      "伏兵",
+      "力強さ",
+      "粘り強さ"
+    ]
   },
   {
     "code": "CAN",
@@ -80,8 +105,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "地元開催で力をつけてきた、上位進出も狙えるチームです。",
     "region": "north_america",
-    "vibeJa": ["スピード", "若さ", "のぼり調子"]
+    "vibeJa": [
+      "スピード",
+      "若さ",
+      "のぼり調子"
+    ]
   },
   {
     "code": "QAT",
@@ -94,8 +124,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "中東の新興国で、世界の強豪に挑む立場のチームです。",
     "region": "asia",
-    "vibeJa": ["テクニック", "組織力", "伏兵"]
+    "vibeJa": [
+      "テクニック",
+      "組織力",
+      "伏兵"
+    ]
   },
   {
     "code": "SUI",
@@ -108,8 +143,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "ヨーロッパの安定した実力国で、上位に食い込める底力があります。",
     "region": "europe",
-    "vibeJa": ["堅守", "組織力", "正確さ"]
+    "vibeJa": [
+      "堅守",
+      "組織力",
+      "正確さ"
+    ]
   },
   {
     "code": "BRA",
@@ -123,8 +163,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "史上最多の優勝を誇る、サッカー王国と呼ばれる最強の一角です。",
     "region": "south_america",
-    "vibeJa": ["テクニック", "スター軍団", "華やか", "伝統国"]
+    "vibeJa": [
+      "テクニック",
+      "スター軍団",
+      "華やか",
+      "伝統国"
+    ]
   },
   {
     "code": "HAI",
@@ -137,8 +183,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "カリブ海からやってきた、強豪に大胆に挑む挑戦者です。",
     "region": "north_america",
-    "vibeJa": ["伏兵", "陽気", "挑戦者"]
+    "vibeJa": [
+      "伏兵",
+      "陽気",
+      "挑戦者"
+    ]
   },
   {
     "code": "MAR",
@@ -151,8 +202,14 @@
     ],
     "style": "defensive",
     "tier": "darkhorse",
+    "tierReasonJa": "アフリカ勢として近年大躍進し、上位を狙える勢いのチームです。",
     "region": "africa",
-    "vibeJa": ["堅守", "組織力", "一体感", "旋風"]
+    "vibeJa": [
+      "堅守",
+      "組織力",
+      "一体感",
+      "旋風"
+    ]
   },
   {
     "code": "SCO",
@@ -165,8 +222,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "サッカー発祥の地のひとつながら、上位に挑む立場のチームです。",
     "region": "europe",
-    "vibeJa": ["闘志", "伝統国", "粘り強さ"]
+    "vibeJa": [
+      "闘志",
+      "伝統国",
+      "粘り強さ"
+    ]
   },
   {
     "code": "USA",
@@ -179,8 +241,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "地元開催で勢いに乗る、上位を狙えるホスト国のひとつです。",
     "region": "north_america",
-    "vibeJa": ["フィジカル", "若さ", "のぼり調子"]
+    "vibeJa": [
+      "フィジカル",
+      "若さ",
+      "のぼり調子"
+    ]
   },
   {
     "code": "PAR",
@@ -193,8 +260,13 @@
     ],
     "style": "defensive",
     "tier": "underdog",
+    "tierReasonJa": "南米の中堅で、強豪ぞろいの中を勝ち抜く挑戦者です。",
     "region": "south_america",
-    "vibeJa": ["堅守", "粘り強さ", "伏兵"]
+    "vibeJa": [
+      "堅守",
+      "粘り強さ",
+      "伏兵"
+    ]
   },
   {
     "code": "AUS",
@@ -207,8 +279,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "アジアを勝ち上がった、世界の強豪に挑むタフな挑戦者です。",
     "region": "oceania",
-    "vibeJa": ["フィジカル", "闘志", "粘り強さ"]
+    "vibeJa": [
+      "フィジカル",
+      "闘志",
+      "粘り強さ"
+    ]
   },
   {
     "code": "TUR",
@@ -221,8 +298,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "若くて勢いのある選手がそろい、上位を脅かせるチームです。",
     "region": "europe",
-    "vibeJa": ["テクニック", "情熱", "旋風"]
+    "vibeJa": [
+      "テクニック",
+      "情熱",
+      "旋風"
+    ]
   },
   {
     "code": "GER",
@@ -236,8 +318,14 @@
     ],
     "style": "balanced",
     "tier": "favorite",
+    "tierReasonJa": "過去に何度も優勝してきた、世界屈指の強豪国です。",
     "region": "europe",
-    "vibeJa": ["組織力", "勝負強さ", "伝統国", "規律"]
+    "vibeJa": [
+      "組織力",
+      "勝負強さ",
+      "伝統国",
+      "規律"
+    ]
   },
   {
     "code": "CUW",
@@ -250,8 +338,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "カリブ海の小さな国で、初出場の歴史的な挑戦者です。",
     "region": "north_america",
-    "vibeJa": ["初出場", "挑戦者", "旋風"]
+    "vibeJa": [
+      "初出場",
+      "挑戦者",
+      "旋風"
+    ]
   },
   {
     "code": "CIV",
@@ -264,8 +357,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "アフリカの実力国として、上位進出を狙える勢いのチームです。",
     "region": "africa",
-    "vibeJa": ["フィジカル", "力強さ", "アフリカの雄"]
+    "vibeJa": [
+      "フィジカル",
+      "力強さ",
+      "アフリカの雄"
+    ]
   },
   {
     "code": "ECU",
@@ -278,8 +376,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "南米予選を勝ち抜いた、伸び盛りで上位を狙えるチームです。",
     "region": "south_america",
-    "vibeJa": ["運動量", "若さ", "スピード"]
+    "vibeJa": [
+      "運動量",
+      "若さ",
+      "スピード"
+    ]
   },
   {
     "code": "NED",
@@ -293,8 +396,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "美しい攻撃で知られ、何度も決勝に迫ってきた強豪国です。",
     "region": "europe",
-    "vibeJa": ["テクニック", "華やか", "伝統国", "組織力"]
+    "vibeJa": [
+      "テクニック",
+      "華やか",
+      "伝統国",
+      "組織力"
+    ]
   },
   {
     "code": "JPN",
@@ -308,8 +417,14 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "アジアの常連で、近年は強豪を倒し上位進出も期待されるチームです。",
     "region": "asia",
-    "vibeJa": ["規律", "組織力", "粘り強さ", "アジアの雄"]
+    "vibeJa": [
+      "規律",
+      "組織力",
+      "粘り強さ",
+      "アジアの雄"
+    ]
   },
   {
     "code": "SWE",
@@ -322,8 +437,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "北欧の実力国ながら、強豪ぞろいの中を挑む立場のチームです。",
     "region": "europe",
-    "vibeJa": ["フィジカル", "組織力", "伝統国"]
+    "vibeJa": [
+      "フィジカル",
+      "組織力",
+      "伝統国"
+    ]
   },
   {
     "code": "TUN",
@@ -336,8 +456,13 @@
     ],
     "style": "defensive",
     "tier": "underdog",
+    "tierReasonJa": "北アフリカの常連で、大舞台では挑戦者の立場のチームです。",
     "region": "africa",
-    "vibeJa": ["堅守", "組織力", "粘り強さ"]
+    "vibeJa": [
+      "堅守",
+      "組織力",
+      "粘り強さ"
+    ]
   },
   {
     "code": "BEL",
@@ -350,8 +475,13 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "近年は世界ランキング上位の常連で、優勝も狙える強豪です。",
     "region": "europe",
-    "vibeJa": ["スター軍団", "テクニック", "個人技"]
+    "vibeJa": [
+      "スター軍団",
+      "テクニック",
+      "個人技"
+    ]
   },
   {
     "code": "EGY",
@@ -364,8 +494,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "アフリカの伝統国ながら、W杯では挑戦者の立場のチームです。",
     "region": "africa",
-    "vibeJa": ["スター", "伝統国", "アフリカの雄"]
+    "vibeJa": [
+      "スター",
+      "伝統国",
+      "アフリカの雄"
+    ]
   },
   {
     "code": "IRN",
@@ -378,8 +513,13 @@
     ],
     "style": "defensive",
     "tier": "underdog",
+    "tierReasonJa": "アジアの常連ですが、世界の強豪相手には挑戦者のチームです。",
     "region": "asia",
-    "vibeJa": ["堅守", "フィジカル", "組織力"]
+    "vibeJa": [
+      "堅守",
+      "フィジカル",
+      "組織力"
+    ]
   },
   {
     "code": "NZL",
@@ -392,8 +532,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "オセアニアの代表として、強豪に挑む元気な挑戦者です。",
     "region": "oceania",
-    "vibeJa": ["フィジカル", "ひたむき", "挑戦者"]
+    "vibeJa": [
+      "フィジカル",
+      "ひたむき",
+      "挑戦者"
+    ]
   },
   {
     "code": "ESP",
@@ -407,8 +552,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "過去に世界一に輝いた、パスサッカーで魅せる強豪国です。",
     "region": "europe",
-    "vibeJa": ["テクニック", "ポゼッション", "華やか", "伝統国"]
+    "vibeJa": [
+      "テクニック",
+      "ポゼッション",
+      "華やか",
+      "伝統国"
+    ]
   },
   {
     "code": "CPV",
@@ -421,8 +572,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "アフリカの小さな島国で、初出場の夢を叶えた挑戦者です。",
     "region": "africa",
-    "vibeJa": ["初出場", "挑戦者", "旋風"]
+    "vibeJa": [
+      "初出場",
+      "挑戦者",
+      "旋風"
+    ]
   },
   {
     "code": "KSA",
@@ -435,8 +591,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "アジアの強豪ですが、世界の舞台では挑戦者の立場のチームです。",
     "region": "asia",
-    "vibeJa": ["勢い", "伏兵", "ジャイキリ"]
+    "vibeJa": [
+      "勢い",
+      "伏兵",
+      "ジャイキリ"
+    ]
   },
   {
     "code": "URU",
@@ -449,8 +610,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "古豪として優勝経験を持ち、上位を脅かせる手強いチームです。",
     "region": "south_america",
-    "vibeJa": ["闘志", "伝統国", "粘り強さ"]
+    "vibeJa": [
+      "闘志",
+      "伝統国",
+      "粘り強さ"
+    ]
   },
   {
     "code": "FRA",
@@ -464,8 +630,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "近年も優勝した、世界の頂点に立つ最強クラスの強豪です。",
     "region": "europe",
-    "vibeJa": ["スター軍団", "スピード", "伝統国", "勝負強さ"]
+    "vibeJa": [
+      "スター軍団",
+      "スピード",
+      "伝統国",
+      "勝負強さ"
+    ]
   },
   {
     "code": "SEN",
@@ -478,8 +650,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "アフリカ王者にもなった、上位を狙える勢いのチームです。",
     "region": "africa",
-    "vibeJa": ["フィジカル", "スピード", "アフリカの雄"]
+    "vibeJa": [
+      "フィジカル",
+      "スピード",
+      "アフリカの雄"
+    ]
   },
   {
     "code": "IRQ",
@@ -492,8 +669,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "中東の中堅で、強豪ぞろいの大舞台に挑む挑戦者です。",
     "region": "asia",
-    "vibeJa": ["情熱", "挑戦者", "粘り強さ"]
+    "vibeJa": [
+      "情熱",
+      "挑戦者",
+      "粘り強さ"
+    ]
   },
   {
     "code": "NOR",
@@ -506,8 +688,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "若い才能が集まり、一気に上位を狙える勢いのチームです。",
     "region": "europe",
-    "vibeJa": ["スター", "フィジカル", "旋風"]
+    "vibeJa": [
+      "スター",
+      "フィジカル",
+      "旋風"
+    ]
   },
   {
     "code": "ARG",
@@ -521,8 +708,14 @@
     ],
     "style": "balanced",
     "tier": "favorite",
+    "tierReasonJa": "前回王者であり、何度も世界一に輝いてきた強豪国です。",
     "region": "south_america",
-    "vibeJa": ["スター軍団", "闘志", "テクニック", "伝統国"]
+    "vibeJa": [
+      "スター軍団",
+      "闘志",
+      "テクニック",
+      "伝統国"
+    ]
   },
   {
     "code": "ALG",
@@ -535,8 +728,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "北アフリカの実力国ながら、大舞台では挑戦者の立場です。",
     "region": "africa",
-    "vibeJa": ["テクニック", "スピード", "伏兵"]
+    "vibeJa": [
+      "テクニック",
+      "スピード",
+      "伏兵"
+    ]
   },
   {
     "code": "AUT",
@@ -549,8 +747,13 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "ヨーロッパで力をつけてきた、上位を狙える伸び盛りのチームです。",
     "region": "europe",
-    "vibeJa": ["プレッシング", "運動量", "組織力"]
+    "vibeJa": [
+      "プレッシング",
+      "運動量",
+      "組織力"
+    ]
   },
   {
     "code": "JOR",
@@ -563,8 +766,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "中東の国で、初出場の歴史的なチャレンジに挑むチームです。",
     "region": "asia",
-    "vibeJa": ["初出場", "のぼり調子", "挑戦者"]
+    "vibeJa": [
+      "初出場",
+      "のぼり調子",
+      "挑戦者"
+    ]
   },
   {
     "code": "COD",
@@ -577,8 +785,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "中部アフリカから挑む、強豪に立ち向かう挑戦者です。",
     "region": "africa",
-    "vibeJa": ["フィジカル", "力強さ", "伏兵"]
+    "vibeJa": [
+      "フィジカル",
+      "力強さ",
+      "伏兵"
+    ]
   },
   {
     "code": "COL",
@@ -591,8 +804,13 @@
     ],
     "style": "attacking",
     "tier": "darkhorse",
+    "tierReasonJa": "南米の実力国で、攻撃力を武器に上位を狙えるチームです。",
     "region": "south_america",
-    "vibeJa": ["テクニック", "陽気", "華やか"]
+    "vibeJa": [
+      "テクニック",
+      "陽気",
+      "華やか"
+    ]
   },
   {
     "code": "POR",
@@ -605,8 +823,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "世界的なスター選手を擁し、優勝も狙える強豪国です。",
     "region": "europe",
-    "vibeJa": ["スター軍団", "個人技", "華やか", "テクニック"]
+    "vibeJa": [
+      "スター軍団",
+      "個人技",
+      "華やか",
+      "テクニック"
+    ]
   },
   {
     "code": "UZB",
@@ -619,8 +843,13 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "中央アジアの国で、初出場の夢を叶えた挑戦者です。",
     "region": "asia",
-    "vibeJa": ["初出場", "組織力", "のぼり調子"]
+    "vibeJa": [
+      "初出場",
+      "組織力",
+      "のぼり調子"
+    ]
   },
   {
     "code": "CRO",
@@ -633,8 +862,14 @@
     ],
     "style": "balanced",
     "tier": "darkhorse",
+    "tierReasonJa": "前回大会で決勝に迫った、上位を脅かす実力のチームです。",
     "region": "europe",
-    "vibeJa": ["テクニック", "粘り強さ", "組織力", "ジャイキリ"]
+    "vibeJa": [
+      "テクニック",
+      "粘り強さ",
+      "組織力",
+      "ジャイキリ"
+    ]
   },
   {
     "code": "ENG",
@@ -648,8 +883,14 @@
     ],
     "style": "attacking",
     "tier": "favorite",
+    "tierReasonJa": "サッカー発祥の地で、近年は決勝に迫る強さを持つ強豪です。",
     "region": "europe",
-    "vibeJa": ["スター軍団", "伝統国", "スピード", "決定力"]
+    "vibeJa": [
+      "スター軍団",
+      "伝統国",
+      "スピード",
+      "決定力"
+    ]
   },
   {
     "code": "GHA",
@@ -662,8 +903,13 @@
     ],
     "style": "attacking",
     "tier": "underdog",
+    "tierReasonJa": "アフリカの常連ですが、強豪相手には挑戦者の立場のチームです。",
     "region": "africa",
-    "vibeJa": ["フィジカル", "若さ", "アフリカの雄"]
+    "vibeJa": [
+      "フィジカル",
+      "若さ",
+      "アフリカの雄"
+    ]
   },
   {
     "code": "PAN",
@@ -676,7 +922,12 @@
     ],
     "style": "balanced",
     "tier": "underdog",
+    "tierReasonJa": "中米から勝ち上がった、強豪に立ち向かう挑戦者です。",
     "region": "north_america",
-    "vibeJa": ["情熱", "ひたむき", "挑戦者"]
+    "vibeJa": [
+      "情熱",
+      "ひたむき",
+      "挑戦者"
+    ]
   }
 ]

--- a/apps/worldcup-kickoff/src/lib/constants/tiers.ts
+++ b/apps/worldcup-kickoff/src/lib/constants/tiers.ts
@@ -1,0 +1,51 @@
+/**
+ * tier（大会での位置づけ）の表示メタデータ。
+ *
+ * バッジの色・ラベル、凡例（TierLegend）で使う「意味」「基準」、注記をここに集約する。
+ * CountryListItem / CountryDetailPanel / TierLegend はこの単一定義を参照し、
+ * 文言・配色のハードコード重複を避ける。
+ */
+import type { TeamTier } from '@/lib/domain'
+import type { BadgeVariant } from '@/components/atoms/Badge'
+
+export interface TierMeta {
+  tier: TeamTier
+  label: string
+  variant: Extract<BadgeVariant, 'gold' | 'pitch' | 'neutral'>
+  summaryJa: string
+  criteriaJa: string
+}
+
+/** favorite → darkhorse → underdog（強い順）。凡例・一覧で使う表示順 */
+export const TIER_ORDER: TeamTier[] = ['favorite', 'darkhorse', 'underdog']
+
+export const TIER_META: Record<TeamTier, TierMeta> = {
+  favorite: {
+    tier: 'favorite',
+    label: '優勝候補',
+    variant: 'gold',
+    summaryJa: '優勝を狙える実力のあるチーム',
+    criteriaJa:
+      '過去に優勝した経験や世界ランキング上位の実績があり、安定して強さを発揮してきた国です。',
+  },
+  darkhorse: {
+    tier: 'darkhorse',
+    label: 'ダークホース',
+    variant: 'pitch',
+    summaryJa: '上位を脅かす勢いのあるチーム',
+    criteriaJa:
+      '優勝候補にもひと泡吹かせそうな勢いや伸びしろがあり、波に乗れば上位進出も夢ではない国です。',
+  },
+  underdog: {
+    tier: 'underdog',
+    label: 'チャレンジャー',
+    variant: 'neutral',
+    summaryJa: '格上に挑む、フレッシュなチーム',
+    criteriaJa:
+      '初出場や久しぶりの出場で、強豪に立ち向かう挑戦者の立場。番狂わせを起こせばお祭り騒ぎです。',
+  },
+}
+
+/** 凡例に添える注記（主観・目安である旨） */
+export const TIER_DISCLAIMER_JA =
+  'これは初心者向けの目安で、編集部の主観です。順位や結果を保証するものではありません。'

--- a/apps/worldcup-kickoff/src/lib/data/index.ts
+++ b/apps/worldcup-kickoff/src/lib/data/index.ts
@@ -1,12 +1,19 @@
 /**
  * データアクセス層の公開エントリ。
  * Server Component は getRepository() 経由でのみデータにアクセスする（JSON直importは禁止）。
- * 将来は環境変数 / feature flag で liveRepository に差し替える。
+ *
+ * 環境変数フラグ WORLDCUP_LIVE_SCORES === 'on' のときだけライブ対応リポジトリを使う。
+ * 既定（未設定/その他）は static で、現状と完全に同一挙動（SSG に影響なし）。
+ * このフラグはサーバー専用（NEXT_PUBLIC_ 接頭辞を付けない）。env はサーバーでのみ参照する。
  */
 import type { WorldCupRepository } from './repository'
 import { staticRepository } from './static-repository'
+import { createLiveRepository } from './live-repository'
 
 export function getRepository(): WorldCupRepository {
+  if (process.env.WORLDCUP_LIVE_SCORES === 'on') {
+    return createLiveRepository(staticRepository)
+  }
   return staticRepository
 }
 

--- a/apps/worldcup-kickoff/src/lib/data/live-repository.test.ts
+++ b/apps/worldcup-kickoff/src/lib/data/live-repository.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createLiveRepository } from './live-repository'
+import type { WorldCupRepository } from './repository'
+import type {
+  Group,
+  GroupStanding,
+  Match,
+  Player,
+  RuleLesson,
+  Stadium,
+  Team,
+  Term,
+} from '@/lib/domain'
+
+// ── 固定フィクスチャ（base が返す静的データ） ──
+
+const team: Team = {
+  code: 'JPN',
+  nameEn: 'Japan',
+  nameJa: '日本',
+  groupId: 'C',
+  flagEmoji: '🇯🇵',
+  confed: 'AFC',
+  region: 'asia',
+  style: 'balanced',
+  tier: 'darkhorse',
+  tierReasonJa: '組織力で上位を狙えるからです。',
+  blurbJa: 'アジアの強豪。',
+  watchPointJa: '組織的な守備が見どころ。',
+  funFactsJa: ['7大会連続出場'],
+  vibeJa: ['組織力'],
+}
+
+const group: Group = {
+  id: 'C',
+  label: 'グループC',
+  teamCodes: ['JPN'],
+}
+
+const stadium: Stadium = {
+  id: 'mexico-city',
+  name: 'Estadio Azteca',
+  city: 'Mexico City',
+  country: 'MEX',
+  timezone: 'UTC-6',
+  capacity: 87000,
+}
+
+const match: Match = {
+  id: 'wc-001',
+  stage: 'group',
+  groupId: 'C',
+  kickoffUtc: '2026-06-11T19:00:00.000Z',
+  homeTeamCode: 'JPN',
+  awayTeamCode: 'KOR',
+  stadiumId: 'mexico-city',
+  score: null,
+  roundLabelJa: 'グループステージ',
+}
+
+const knockoutMatch: Match = {
+  id: 'wc-073',
+  stage: 'round32',
+  groupId: null,
+  kickoffUtc: '2026-06-28T19:00:00.000Z',
+  homeTeamCode: null,
+  awayTeamCode: null,
+  homePlaceholderJa: 'A組2位',
+  awayPlaceholderJa: '3位通過(A/B/C/D/F組)',
+  stadiumId: 'mexico-city',
+  score: null,
+  roundLabelJa: 'ラウンド32',
+}
+
+const player: Player = {
+  id: 'JPN-1',
+  nameJa: '遠藤 航',
+  teamCode: 'JPN',
+  position: 'MF',
+  highlightJa: '中盤の要。',
+}
+
+const term: Term = {
+  slug: 'offside',
+  termJa: 'オフサイド',
+  definitionJa: '攻撃側の反則。',
+  category: 'rule',
+}
+
+const ruleLesson: RuleLesson = {
+  slug: 'offside',
+  titleJa: 'オフサイド入門',
+  order: 1,
+  estimatedMinutes: 3,
+  bodyBlocks: [{ type: 'paragraph', text: '基本の解説。' }],
+  interactive: null,
+  relatedTermSlugs: ['offside'],
+}
+
+const standing: GroupStanding = {
+  teamCode: 'JPN',
+  played: 1,
+  won: 1,
+  drawn: 0,
+  lost: 0,
+  goalsFor: 2,
+  goalsAgainst: 0,
+  goalDifference: 2,
+  points: 3,
+  rank: 1,
+}
+
+/** WorldCupRepository を満たす最小のフェイク base。各メソッドは固定値を返すスパイ。 */
+function makeFakeBase(): WorldCupRepository {
+  return {
+    getTeams: vi.fn(async () => [team]),
+    getTeamByCode: vi.fn(async () => team),
+    getGroups: vi.fn(async () => [group]),
+    getStadiums: vi.fn(async () => [stadium]),
+    getMatches: vi.fn(async () => [match, knockoutMatch]),
+    getMatchesByGroup: vi.fn(async () => [match]),
+    getMatchesByTeam: vi.fn(async () => [match]),
+    getKnockoutMatches: vi.fn(async () => [knockoutMatch]),
+    getGroupStandings: vi.fn(async () => [standing]),
+    getPlayersByTeam: vi.fn(async () => [player]),
+    getTerms: vi.fn(async () => [term]),
+    getRuleLessons: vi.fn(async () => [ruleLesson]),
+    getRuleLesson: vi.fn(async () => ruleLesson),
+  }
+}
+
+describe('createLiveRepository', () => {
+  let originalApiKey: string | undefined
+  let originalApiBase: string | undefined
+
+  beforeEach(() => {
+    originalApiKey = process.env.WORLDCUP_LIVE_API_KEY
+    originalApiBase = process.env.WORLDCUP_LIVE_API_BASE
+    // ライブ取得を無効化（= 完全に静的フォールバック）した状態を既定にする
+    delete process.env.WORLDCUP_LIVE_API_KEY
+    delete process.env.WORLDCUP_LIVE_API_BASE
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    if (originalApiKey === undefined) delete process.env.WORLDCUP_LIVE_API_KEY
+    else process.env.WORLDCUP_LIVE_API_KEY = originalApiKey
+    if (originalApiBase === undefined) delete process.env.WORLDCUP_LIVE_API_BASE
+    else process.env.WORLDCUP_LIVE_API_BASE = originalApiBase
+  })
+
+  it('WorldCupRepository を満たすオブジェクトを返す', () => {
+    const repo = createLiveRepository(makeFakeBase())
+    const methods: (keyof WorldCupRepository)[] = [
+      'getTeams',
+      'getTeamByCode',
+      'getGroups',
+      'getStadiums',
+      'getMatches',
+      'getMatchesByGroup',
+      'getMatchesByTeam',
+      'getKnockoutMatches',
+      'getGroupStandings',
+      'getPlayersByTeam',
+      'getTerms',
+      'getRuleLessons',
+      'getRuleLesson',
+    ]
+    for (const m of methods) {
+      expect(typeof repo[m]).toBe('function')
+    }
+  })
+
+  // ── 静的コンテンツ系: base へ委譲する ──
+
+  describe('静的コンテンツ系は base に委譲する', () => {
+    it('getTeams は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getTeams()).resolves.toEqual([team])
+      expect(base.getTeams).toHaveBeenCalledTimes(1)
+    })
+
+    it('getTeamByCode は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getTeamByCode('JPN')).resolves.toEqual(team)
+      expect(base.getTeamByCode).toHaveBeenCalledWith('JPN')
+    })
+
+    it('getGroups は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getGroups()).resolves.toEqual([group])
+      expect(base.getGroups).toHaveBeenCalledTimes(1)
+    })
+
+    it('getStadiums は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getStadiums()).resolves.toEqual([stadium])
+      expect(base.getStadiums).toHaveBeenCalledTimes(1)
+    })
+
+    it('getPlayersByTeam は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getPlayersByTeam('JPN')).resolves.toEqual([player])
+      expect(base.getPlayersByTeam).toHaveBeenCalledWith('JPN')
+    })
+
+    it('getTerms は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getTerms()).resolves.toEqual([term])
+      expect(base.getTerms).toHaveBeenCalledTimes(1)
+    })
+
+    it('getRuleLessons は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getRuleLessons()).resolves.toEqual([ruleLesson])
+      expect(base.getRuleLessons).toHaveBeenCalledTimes(1)
+    })
+
+    it('getRuleLesson は base の結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getRuleLesson('offside')).resolves.toEqual(ruleLesson)
+      expect(base.getRuleLesson).toHaveBeenCalledWith('offside')
+    })
+  })
+
+  // ── ライブ対象系: env 未設定時は base へフォールバック ──
+
+  describe('ライブ取得が無効（env 未設定）なら base 値へフォールバックする', () => {
+    it('getMatches は base と同じ結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getMatches()).resolves.toEqual([match, knockoutMatch])
+      expect(base.getMatches).toHaveBeenCalledTimes(1)
+    })
+
+    it('getMatchesByGroup は base と同じ結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getMatchesByGroup('C')).resolves.toEqual([match])
+      expect(base.getMatchesByGroup).toHaveBeenCalledWith('C')
+    })
+
+    it('getMatchesByTeam は base と同じ結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getMatchesByTeam('JPN')).resolves.toEqual([match])
+      expect(base.getMatchesByTeam).toHaveBeenCalledWith('JPN')
+    })
+
+    it('getKnockoutMatches は base と同じ結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getKnockoutMatches()).resolves.toEqual([knockoutMatch])
+      expect(base.getKnockoutMatches).toHaveBeenCalledTimes(1)
+    })
+
+    it('getGroupStandings は base（静的計算）と同じ結果を返す', async () => {
+      const base = makeFakeBase()
+      const repo = createLiveRepository(base)
+      await expect(repo.getGroupStandings('C')).resolves.toEqual([standing])
+      expect(base.getGroupStandings).toHaveBeenCalledWith('C')
+    })
+  })
+
+  // ── env が設定されていてもスタブは null 返却 → 静的と同挙動 ──
+
+  it('env が設定されていてもライブはスタブのため base 値へフォールバックする', async () => {
+    process.env.WORLDCUP_LIVE_API_KEY = 'dummy-key'
+    process.env.WORLDCUP_LIVE_API_BASE = 'https://example.test/api'
+    const base = makeFakeBase()
+    const repo = createLiveRepository(base)
+    await expect(repo.getMatches()).resolves.toEqual([match, knockoutMatch])
+    await expect(repo.getGroupStandings('C')).resolves.toEqual([standing])
+  })
+})

--- a/apps/worldcup-kickoff/src/lib/data/live-repository.ts
+++ b/apps/worldcup-kickoff/src/lib/data/live-repository.ts
@@ -1,0 +1,200 @@
+/**
+ * ライブスコア対応リポジトリ（雛形 / #30）。
+ *
+ * `WorldCupRepository` を実装するデコレータ。base（既定は staticRepository）を包み、
+ * - 静的コンテンツ系メソッド（チーム・グループ・会場・選手・用語・ルール）は base へそのまま委譲し、
+ * - 試合・順位など「ライブ反映の対象になりうる」メソッドだけ、ライブスナップショットを取得して
+ *   静的結果にマージする。
+ *
+ * 設計上の最優先事項は **可用性** で、ライブ取得が失敗・無効でも必ず base の静的結果へ
+ * フォールバックする（外部API障害でアプリが落ちないこと）。現時点では `fetchLiveSnapshot()`
+ * はスタブで、環境変数が未設定なら常に null を返す（= 完全に静的と同挙動）。
+ *
+ * 採用API候補・キャッシュ/再検証方針・取得設計の評価は docs/live-score-api-evaluation.md を参照。
+ */
+import type {
+  CountryCode,
+  Group,
+  GroupId,
+  GroupStanding,
+  Match,
+  Player,
+  RuleLesson,
+  Stadium,
+  Team,
+  Term,
+} from '@/lib/domain'
+import type { WorldCupRepository } from './repository'
+import { staticRepository } from './static-repository'
+
+/**
+ * ライブAPIから一度に取得するスナップショット（雛形）。
+ *
+ * 試合の最新スコア／ステータスや順位など、ライブ反映の対象を1リクエストにまとめて持つ想定。
+ * 実装時は openfootball 形式ではなく、採用API（下記候補）のレスポンスを内部ドメイン型へ
+ * 正規化したうえでここに格納する。
+ *
+ * - matchesById: Match.id（"wc-001"形式）→ 最新試合状態。base の試合に上書きマージする。
+ * - standingsByGroup: GroupId → ライブ順位。存在すれば computeStandings の代わりに採用する。
+ */
+interface LiveSnapshot {
+  /** Match.id → ライブ反映済みの試合。base に存在するもののみ上書きする想定 */
+  matchesById: Map<string, Match>
+  /** GroupId → ライブ順位表。無ければ base（静的計算）にフォールバック */
+  standingsByGroup: Map<GroupId, GroupStanding[]>
+}
+
+/**
+ * ライブスナップショットを取得する（**現時点ではスタブ**）。
+ *
+ * 実API呼び出しは行わない。サーバー専用の環境変数が未設定なら即 null を返し、
+ * 呼び出し側は base（静的）へフォールバックする。
+ *
+ * --- 実装方針（TODO / #30 本実装時） ---
+ * - **サーバー専用 fetch**: この関数はサーバー（Server Component / Route Handler）からのみ
+ *   呼ばれる。APIキーは下記のとおりサーバー専用 env で参照し、クライアントへは絶対に渡さない。
+ * - **キャッシュ / 再検証**: 改変版 Next の data fetching ガイド
+ *   （node_modules/next/dist/docs/）を必ず確認したうえで、`fetch` の revalidate（時間ベース ISR）
+ *   もしくはタグ再検証を用い、試合中のみ短い間隔で再取得する。SSG ページの挙動を壊さないこと。
+ * - **採用API候補**: docs/live-score-api-evaluation.md にて評価中
+ *   （例: API-Football / football-data.org / openfootball 更新フィード 等）。
+ * - **正規化**: 取得レスポンスは内部ドメイン型（Match / GroupStanding）へ正規化してから返す。
+ * - **失敗時**: 例外は内部で握り潰し、必ず null を返す（呼び出し側の静的フォールバックに委ねる）。
+ */
+async function fetchLiveSnapshot(): Promise<LiveSnapshot | null> {
+  // キーは必ずサーバー専用（NEXT_PUBLIC_ 接頭辞を使わない）。env はサーバーでのみ参照する。
+  const apiKey = process.env.WORLDCUP_LIVE_API_KEY
+  const apiBase = process.env.WORLDCUP_LIVE_API_BASE
+
+  // 未設定なら即 null（= 静的と完全に同挙動）。実APIは呼ばない。
+  if (!apiKey || !apiBase) {
+    return null
+  }
+
+  try {
+    // TODO(#30): ここで実API（apiBase）をサーバー専用 fetch で呼び、
+    //   レスポンスを LiveSnapshot へ正規化して返す。
+    //   現時点では実装せず、設定があっても安全側に倒して null を返す。
+    return null
+  } catch (error) {
+    // 障害は記録だけして握り潰し、静的フォールバックへ。
+    console.error('[live-repository] fetchLiveSnapshot に失敗しました', error)
+    return null
+  }
+}
+
+/**
+ * base の試合配列にライブスナップショットを上書きマージする。
+ * snapshot が null、または該当試合がスナップショットに無ければ base の値を保つ。
+ */
+function mergeMatches(base: Match[], snapshot: LiveSnapshot | null): Match[] {
+  if (!snapshot) return base
+  return base.map((m) => snapshot.matchesById.get(m.id) ?? m)
+}
+
+/**
+ * ライブ対応リポジトリを生成する。
+ *
+ * @param base 委譲先（既定は静的リポジトリ）。テスト時は差し替え可能。
+ */
+export function createLiveRepository(
+  base: WorldCupRepository = staticRepository,
+): WorldCupRepository {
+  return {
+    // ── 静的コンテンツ系: そのまま委譲（ライブ反映なし） ──
+    getTeams(): Promise<Team[]> {
+      return base.getTeams()
+    },
+
+    getTeamByCode(code: CountryCode): Promise<Team | null> {
+      return base.getTeamByCode(code)
+    },
+
+    getGroups(): Promise<Group[]> {
+      return base.getGroups()
+    },
+
+    getStadiums(): Promise<Stadium[]> {
+      return base.getStadiums()
+    },
+
+    getPlayersByTeam(code: CountryCode): Promise<Player[]> {
+      return base.getPlayersByTeam(code)
+    },
+
+    getTerms(): Promise<Term[]> {
+      return base.getTerms()
+    },
+
+    getRuleLessons(): Promise<RuleLesson[]> {
+      return base.getRuleLessons()
+    },
+
+    getRuleLesson(slug: string): Promise<RuleLesson | null> {
+      return base.getRuleLesson(slug)
+    },
+
+    // ── ライブ反映の対象: 取得を try し、失敗・無効なら必ず base へフォールバック ──
+    async getMatches(): Promise<Match[]> {
+      const baseMatches = await base.getMatches()
+      try {
+        const snapshot = await fetchLiveSnapshot()
+        return mergeMatches(baseMatches, snapshot)
+      } catch (error) {
+        console.error('[live-repository] getMatches フォールバック', error)
+        return baseMatches
+      }
+    },
+
+    async getMatchesByGroup(groupId: GroupId): Promise<Match[]> {
+      const baseMatches = await base.getMatchesByGroup(groupId)
+      try {
+        const snapshot = await fetchLiveSnapshot()
+        return mergeMatches(baseMatches, snapshot)
+      } catch (error) {
+        console.error(
+          '[live-repository] getMatchesByGroup フォールバック',
+          error,
+        )
+        return baseMatches
+      }
+    },
+
+    async getMatchesByTeam(code: CountryCode): Promise<Match[]> {
+      const baseMatches = await base.getMatchesByTeam(code)
+      try {
+        const snapshot = await fetchLiveSnapshot()
+        return mergeMatches(baseMatches, snapshot)
+      } catch (error) {
+        console.error('[live-repository] getMatchesByTeam フォールバック', error)
+        return baseMatches
+      }
+    },
+
+    async getKnockoutMatches(): Promise<Match[]> {
+      const baseMatches = await base.getKnockoutMatches()
+      try {
+        const snapshot = await fetchLiveSnapshot()
+        return mergeMatches(baseMatches, snapshot)
+      } catch (error) {
+        console.error(
+          '[live-repository] getKnockoutMatches フォールバック',
+          error,
+        )
+        return baseMatches
+      }
+    },
+
+    async getGroupStandings(groupId: GroupId): Promise<GroupStanding[]> {
+      const baseStandings = await base.getGroupStandings(groupId)
+      try {
+        const snapshot = await fetchLiveSnapshot()
+        // ライブ順位があればそれを採用、無ければ静的計算（base）へフォールバック。
+        return snapshot?.standingsByGroup.get(groupId) ?? baseStandings
+      } catch (error) {
+        console.error('[live-repository] getGroupStandings フォールバック', error)
+        return baseStandings
+      }
+    },
+  }
+}

--- a/apps/worldcup-kickoff/src/lib/data/normalize.test.ts
+++ b/apps/worldcup-kickoff/src/lib/data/normalize.test.ts
@@ -122,6 +122,7 @@ const content: CountryContent[] = [
     funFactsJa: ['f'],
     style: 'balanced',
     tier: 'darkhorse',
+    tierReasonJa: '安定した組織力で上位を狙えるからです。',
     region: 'asia',
     vibeJa: ['組織力'],
   },
@@ -133,6 +134,7 @@ const content: CountryContent[] = [
     funFactsJa: ['f'],
     style: 'attacking',
     tier: 'underdog',
+    tierReasonJa: '勢いはありますが格上に挑む立場だからです。',
     region: 'asia',
     vibeJa: ['運動量'],
   },
@@ -168,6 +170,8 @@ describe('normalizeTeams', () => {
     expect(jpn.style).toBe('balanced')
     expect(jpn.region).toBe('asia')
     expect(jpn.vibeJa).toEqual(['組織力'])
+    expect(jpn.tier).toBe('darkhorse')
+    expect(jpn.tierReasonJa).toBe('安定した組織力で上位を狙えるからです。')
   })
 
   it('コンテンツ欠落時はエラー', () => {

--- a/apps/worldcup-kickoff/src/lib/data/normalize.ts
+++ b/apps/worldcup-kickoff/src/lib/data/normalize.ts
@@ -63,6 +63,7 @@ export interface CountryContent {
   funFactsJa: string[]
   style: TeamStyle
   tier: TeamTier
+  tierReasonJa: string
   region: TeamRegion
   vibeJa: string[]
 }
@@ -197,6 +198,7 @@ export function normalizeTeams(
       region: content.region,
       style: content.style,
       tier: content.tier,
+      tierReasonJa: content.tierReasonJa,
       blurbJa: content.blurbJa,
       watchPointJa: content.watchPointJa,
       funFactsJa: content.funFactsJa,

--- a/apps/worldcup-kickoff/src/lib/domain/team.ts
+++ b/apps/worldcup-kickoff/src/lib/domain/team.ts
@@ -49,6 +49,8 @@ export interface Team {
   style: TeamStyle
   /** 大会での位置づけ（診断用） */
   tier: TeamTier
+  /** なぜその tier なのかの一言理由（国詳細・凡例導線で表示） */
+  tierReasonJa: string
   /** 初心者向け一言紹介 */
   blurbJa: string
   /** 観戦ポイント */


### PR DESCRIPTION
## 概要

worldcup-kickoff の issue #27 / #28 / #30 を委譲型PDCA（content-creator / cost-analyzer / backend-developer / frontend-developer / test-writer）で実装。CTO/CPO レビュー済み。

> **#29（ui-ux-designer エージェント新設）は本PRに含みません。** `.claude/agents/*.md` の作成が auto-mode 分類器にブロックされ、Hiro 判断で今回は見送り。エージェント本体＋ドキュメントは別途セットで対応します。

## #27 [P0] tier根拠と凡例

- `Team` / `CountryContent` に `tierReasonJa` を追加し `normalizeTeams` でマージ
- tier 表示メタを `src/lib/constants/tiers.ts` に集約（`CountryListItem` / `CountryDetailPanel` で重複していた `TIER_META` を DRY 化）
- 3 tier の定義・基準・注記（主観/目安である旨）＋ **48カ国全ての `tierReasonJa`** を整備
- `TierLegend`（凡例の中身）/ `TierLegendDialog`（モーダル・`TermPopover` の a11y 作法を踏襲：`role=dialog`・`aria-modal`・Escape/backdrop で閉じトリガーへフォーカス復帰・body スクロール抑止）を新設
- /countries 上部に凡例導線、国詳細でバッジ→凡例モーダル＋「なぜ◯◯？」を表示

## #28 [P1] PC余白の装飾

- `DeskDecor`（純装飾・`aria-hidden`/`pointer-events-none`）を新設
- **lg+ のみ**（`hidden lg:block`）左右ガターに芝目・紙吹雪・トロフィー/ボール SVG を淡く配置。**モバイルの見た目・サイズは不変**
- 配色トークン経由（hex なし）/ `motion-safe` で浮遊（reduced-motion は無効化）/ `fixed inset-0 overflow-hidden` で横スクロール防止 / `z-0` 最背面

## #30 [P2] ライブスコアAPI（評価＋雛形）

- 評価ドキュメント `docs/live-score-api-evaluation.md`：API比較（推奨 API-Football Pro、フォールバック football-data.org、worldcupapi 不採用）・無料枠/レート/ライセンスのリスク・ポーリング設計案（一部「未確認」を明記）
- `createLiveRepository` 雛形：`WORLDCUP_LIVE_SCORES=on` のときのみ有効、**既定は static で現状と完全同挙動**、API 障害時は静的フォールバック、キーは**サーバー専用**（`NEXT_PUBLIC_` 不使用）

## 検証

- `pnpm test`: **364件 全 pass**（新規: TierLegend / TierLegendDialog / DeskDecor / live-repository、既存 fixture の `tierReasonJa` 追従も修正）
- `pnpm lint`: クリーン / `tsc --noEmit`: エラーなし
- `pnpm build`: **成功（全70ページ SSG、48カ国詳細含む）**。flag-gated 化で SSG への影響なし

Closes #27
Closes #28
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
